### PR TITLE
Use persist-output from specific cf-operator version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,12 @@ jobs:
         - export KUBECONFIG="$(kind get kubeconfig-path)"
         - export USE_KIND="true"
 
+        # Set CF-OPERATER Docker Image Tag
+        - export DOCKER_IMAGE_TAG="v0.4.2-0.g604925f0"
+        # For PersistOutput container command
+        - docker pull docker.io/cfcontainerization/cf-operator:v0.4.2-0.g604925f0
+        - kind load docker-image docker.io/cfcontainerization/cf-operator:v0.4.2-0.g604925f0
+
         # Download and install helm
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh
         - chmod 700 get_helm.sh

--- a/integration/environment/operator.go
+++ b/integration/environment/operator.go
@@ -37,7 +37,7 @@ func (e *Environment) setupOperator() (manager.Manager, error) {
 
 	dockerImageRepo, found := os.LookupEnv("DOCKER_IMAGE_REPOSITORY")
 	if !found {
-		dockerImageRepo = "quarks-job"
+		dockerImageRepo = "cf-operator"
 	}
 
 	dockerImageTag, found := os.LookupEnv("DOCKER_IMAGE_TAG")

--- a/pkg/kube/controllers/extendedjob/errand_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler.go
@@ -33,7 +33,7 @@ const (
 	// EnvPodOrdinal is the pod's index
 	EnvPodOrdinal = "POD_ORDINAL"
 	// EnvNamespace is the namespace in which cf-operator runs
-	EnvNamespace = "OPERATOR_NAMESPACE"
+	EnvNamespace = "CF_OPERATOR_NAMESPACE"
 )
 
 // NewErrandReconciler returns a new reconciler for errand jobs.


### PR DESCRIPTION
Until the cf operator can use persist-output via the quarks-job binary,
provide compatibility in master