### PR TITLE
Docker image tag defaults to quarks-job version

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -105,7 +105,7 @@ func init() {
 	cmd.KubeConfigFlags(pf, argToEnv)
 	cmd.LoggerFlags(pf, argToEnv)
 	cmd.NamespacesFlags(pf, argToEnv, namespaceArg)
-	cmd.DockerImageFlags(pf, argToEnv)
+	cmd.DockerImageFlags(pf, argToEnv, version.Version)
 	cmd.ApplyCRDsFlags(pf, argToEnv)
 
 	pf.Int("max-workers", 1, "Maximum number of workers concurrently running the controller")

--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -37,7 +37,7 @@ var _ = Describe("CLI", func() {
   -o, --docker-image-org string           \(DOCKER_IMAGE_ORG\) Dockerhub organization that provides the operator docker image \(default "cfcontainerization"\)
       --docker-image-pull-policy string   \(DOCKER_IMAGE_PULL_POLICY\) Image pull policy \(default "IfNotPresent"\)
   -r, --docker-image-repository string    \(DOCKER_IMAGE_REPOSITORY\) Dockerhub repository that provides the operator docker image \(default "cf-operator"\)
-  -t, --docker-image-tag string           \(DOCKER_IMAGE_TAG\) Tag of the operator docker image
+  -t, --docker-image-tag string           \(DOCKER_IMAGE_TAG\) Tag of the operator docker image \(default "\d+.\d+.\d+"\)
   -h, --help                              help for quarks-job
   -c, --kubeconfig string                 \(KUBECONFIG\) Path to a kubeconfig, not required in-cluster
   -l, --log-level string                  \(LOG_LEVEL\) Only print log messages from this level onward \(default "debug"\)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/quarks-job
 
 require (
-	code.cloudfoundry.org/quarks-utils v0.0.0-20191018134429-cc28e8825a4c
+	code.cloudfoundry.org/quarks-utils v0.0.0-20191024142927-02f6003e7fbb
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-code.cloudfoundry.org/quarks-utils v0.0.0-20191018134429-cc28e8825a4c h1:FvKvpWV1pS92dB2rAgC+zyp3+9UHPL9PPS88A51aiLE=
-code.cloudfoundry.org/quarks-utils v0.0.0-20191018134429-cc28e8825a4c/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191024142927-02f6003e7fbb h1:jZ7oAsKKXRiBGsQnAiPmVMylVmQHBg5JZDWj3WExJ6M=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191024142927-02f6003e7fbb/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=


### PR DESCRIPTION
This is using a branch of quarks-utils to avoid the incompatibilities in master.