### PR TITLE
Revert "DRY up code by using the VersionedSecretStore"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,6 @@ jobs:
 
         # Set CF-OPERATER Docker Image Tag
         - export DOCKER_IMAGE_TAG="v0.4.2-0.g604925f0"
-        # For PersistOutput container command
-        - docker pull docker.io/cfcontainerization/cf-operator:v0.4.2-0.g604925f0
-        - kind load docker-image docker.io/cfcontainerization/cf-operator:v0.4.2-0.g604925f0
 
         # Download and install helm
         - curl https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get > get_helm.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,4 @@ RUN groupadd -g 1000 quarks && \
     useradd -r -u 1000 -g quarks quarks
 USER quarks
 COPY --from=build /usr/local/bin/quarks-job /usr/local/bin/quarks-job
-ENTRYPOINT ["/tini", "--"]
-CMD ["/usr/local/bin/quarks-job"]
+ENTRYPOINT ["/tini", "--", "/usr/local/bin/quarks-job"]

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/quarks-job
 
 require (
-	code.cloudfoundry.org/quarks-utils v0.0.0-20191024142927-02f6003e7fbb
+	code.cloudfoundry.org/quarks-utils v0.0.0-20191028091215-830d8d07ee67
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-code.cloudfoundry.org/quarks-utils v0.0.0-20191024142927-02f6003e7fbb h1:jZ7oAsKKXRiBGsQnAiPmVMylVmQHBg5JZDWj3WExJ6M=
-code.cloudfoundry.org/quarks-utils v0.0.0-20191024142927-02f6003e7fbb/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191028091215-830d8d07ee67 h1:n/yH3UyKOEZFuykJYHQk3fjihZELMREwUAuXX0YXSNc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20191028091215-830d8d07ee67/go.mod h1:H6fVNegFsTZqOU2Cggvue8X5vfAdeGDKemikmwc7RBc=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/pkg/kube/controllers/extendedjob/errand_reconciler.go
+++ b/pkg/kube/controllers/extendedjob/errand_reconciler.go
@@ -33,7 +33,7 @@ const (
 	// EnvPodOrdinal is the pod's index
 	EnvPodOrdinal = "POD_ORDINAL"
 	// EnvNamespace is the namespace in which cf-operator runs
-	EnvNamespace = "CF_OPERATOR_NAMESPACE"
+	EnvNamespace = "OPERATOR_NAMESPACE"
 )
 
 // NewErrandReconciler returns a new reconciler for errand jobs.

--- a/pkg/kube/controllers/extendedjob/job_creator.go
+++ b/pkg/kube/controllers/extendedjob/job_creator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
 	batchv1 "k8s.io/api/batch/v1"
@@ -133,19 +132,12 @@ func (j jobCreatorImpl) Create(ctx context.Context, eJob ejv1.ExtendedJob, names
 	// Set serviceaccount to the container
 	template.Spec.Template.Spec.Volumes = append(template.Spec.Template.Spec.Volumes, serviceAccountVolume)
 
-	image := config.GetOperatorDockerImage()
-	image = strings.Replace(image, "quarks-job", "cf-operator", 1)
 	// Create a container for persisting output
 	outputPersistContainer := corev1.Container{
 		Name:            "output-persist",
 		Image:           config.GetOperatorDockerImage(),
 		ImagePullPolicy: config.GetOperatorImagePullPolicy(),
-		Command:         []string{"/usr/bin/dumb-init", "--"},
-		Args: []string{
-			"/bin/sh",
-			"-xc",
-			"cf-operator util persist-output",
-		},
+		Args:            []string{"persist-output"},
 		Env: []corev1.EnvVar{
 			{
 				Name:  EnvNamespace,

--- a/pkg/kube/controllers/extendedjob/job_creator.go
+++ b/pkg/kube/controllers/extendedjob/job_creator.go
@@ -138,7 +138,7 @@ func (j jobCreatorImpl) Create(ctx context.Context, eJob ejv1.ExtendedJob, names
 	// Create a container for persisting output
 	outputPersistContainer := corev1.Container{
 		Name:            "output-persist",
-		Image:           image,
+		Image:           config.GetOperatorDockerImage(),
 		ImagePullPolicy: config.GetOperatorImagePullPolicy(),
 		Command:         []string{"/usr/bin/dumb-init", "--"},
 		Args: []string{

--- a/pkg/kube/util/reference/reconciles.go
+++ b/pkg/kube/util/reference/reconciles.go
@@ -66,7 +66,7 @@ func GetReconciles(ctx context.Context, client crc.Client, reconcileType Reconci
 				keys[i] = k
 				i++
 			}
-			ok := vss.ContainsOutdatedSecretName(keys, name)
+			ok := vss.ContainsSecretName(keys, name)
 			return ok, nil
 		}
 


### PR DESCRIPTION
This reverts commits from https://github.com/cloudfoundry-incubator/quarks-job/pull/11

That PR was merged without it's corresponding PR in utils and breaks the public API. The utils PR for that change is untested with cf-operator master. To clear master for other PRs let's revert this, until the whole set of PRs is ready.

