### PR TITLE
Add dev-env-kind.yml

### DIFF
--- a/dev-env-kind.yml
+++ b/dev-env-kind.yml
@@ -1,0 +1,93 @@
+#
+#
+# The dev-env-kind.yaml packs a development flow
+# for running quarks-job inside a k8s 
+# cluster via kind into a single configuration file.
+# This flow involves:
+# - compiling a binary
+# - building a Docker img using the above binary
+# - Installing a helm chart using the above docker img
+#
+#
+# To download the latest havener, please refer to https://github.com/homeport/havener,
+# or trigger the following cmd:
+# curl -sL https://raw.githubusercontent.com/homeport/havener/master/scripts/download-latest.sh | bash
+#
+#
+# To install the charts, run it as follows:
+#
+# havener deploy --config dev-env-kind.yaml
+#
+# Make sure:
+#
+# - You have created a kind cluster named "kubecf", e.g.:
+#   `kind create cluster --name=kubecf`
+#
+# - Tiller is up and running, you can make use of the following:
+#
+  # helm init
+  # kubectl create serviceaccount --namespace kube-system tiller
+  # kubectl create clusterrolebinding tiller-cluster-rule --clusterrole=cluster-admin --serviceaccount=kube-system:tiller
+  # kubectl patch deploy --namespace kube-system tiller-deploy -p '{"spec":{"template":{"spec":{"serviceAccount":"tiller"}}}}'
+#
+
+
+name: quarks-job
+releases:
+- name: quarks-job
+  namespace: cfo
+  location: deploy/helm/quarks-job/
+  overrides:
+    image:
+      tag: (( env DOCKER_IMAGE_TAG ))
+      repository: (( env DOCKER_REPOSITORY ))
+      org: (( env DOCKER_ORGANIZATION ))
+    customResources:
+      enableInstallation: (( env CRDS_ENABLED ))
+    global:
+      operator:
+        watchNamespace: "kubecf"
+
+env:
+  DOCKER_IMAGE_TAG: (( shell . bin/include/versioning && echo "${ARTIFACT_VERSION}" ))
+  DOCKER_REPOSITORY: quarks-job
+  DOCKER_ORGANIZATION: cfcontainerization
+  CRDS_ENABLED: false
+  GO111MODULE: (( shell echo "${GO111MODULE}" ))
+
+before:
+- cmd: /bin/bash
+  args:
+  - -c
+  - |
+    #!/bin/bash
+    set -euo -x pipefail
+
+    export KIND_CLUSTER_NAME=kubecf
+
+    # SOME VALIDATIONS FOR BINARIES
+    set +e
+    kind get clusters | grep "${KIND_CLUSTER_NAME}"
+      if [ $? -ne 0 ]; then
+        echo "PLEASE ENSURE YOU HAVE A RUNNING KIND CLUSTER, see the comments on the top of this file."; exit 1
+      fi
+
+      helm version > /dev/null 2>&1
+      if [ $? -ne 0 ]; then
+        echo "PLEASE ENSURE TILLER IS UP AND RUNNING, see the comments on the top of this file."; exit 1
+      fi
+    set -e
+
+    # SET REQUIRED ENVIRONMENT VARIABLES
+    export GO111MODULE=${GO111MODULE:-on}
+    export KUBECONFIG="$(kind get kubeconfig-path --name=${KIND_CLUSTER_NAME})"
+
+    # BUILD QUARKS-JOB IMG
+    . bin/include/versioning
+    . bin/include/docker
+    echo "Tag for docker image is ${ARTIFACT_VERSION}"
+
+    ./bin/build-image
+
+    echo "quarks-job docker image is ${DOCKER_IMAGE_ORG}/${DOCKER_IMAGE_REPOSITORY}:${ARTIFACT_VERSION}"
+    kind load docker-image "${DOCKER_IMAGE_ORG}/${DOCKER_REPOSITORY}:${ARTIFACT_VERSION}" --loglevel debug --name=${KIND_CLUSTER_NAME}


### PR DESCRIPTION
This simplifies a lot the deployment of a develepmont environment
for running the quarks-job via helm.

In the cf-operator repo, there is a similar file, to deploy the cf-operator
helm chart.