### PR TITLE
Use pre-existing service account

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -15,9 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"code.cloudfoundry.org/quarks-job/pkg/kube/operator"
+	"code.cloudfoundry.org/quarks-job/pkg/kube/util/config"
 	"code.cloudfoundry.org/quarks-job/version"
 	"code.cloudfoundry.org/quarks-utils/pkg/cmd"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	sharedcfg "code.cloudfoundry.org/quarks-utils/pkg/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 )
 
@@ -43,18 +44,18 @@ var rootCmd = &cobra.Command{
 
 		cfg := config.NewDefaultConfig(afero.NewOsFs())
 
-		watchNamespace := cmd.Namespaces(cfg, log, namespaceArg)
+		watchNamespace := cmd.Namespaces(cfg.Config, log, namespaceArg)
 		log.Infof("Starting quarks-job %s with namespace %s", version.Version, watchNamespace)
 
 		err = cmd.DockerImage()
 		if err != nil {
 			return wrapError(err, "")
 		}
-		log.Infof("quarks-job docker image: %s", config.GetOperatorDockerImage())
+		log.Infof("quarks-job docker image: %s", sharedcfg.GetOperatorDockerImage())
 
 		cfg.MaxQuarksJobWorkers = viper.GetInt("max-workers")
 
-		cmd.CtxTimeOut(cfg)
+		cmd.CtxTimeOut(cfg.Config)
 
 		ctx := ctxlog.NewParentContext(log)
 

--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -55,6 +55,12 @@ var rootCmd = &cobra.Command{
 
 		cfg.MaxQuarksJobWorkers = viper.GetInt("max-workers")
 
+		serviceAccount := viper.GetString("service-account")
+		if serviceAccount == "" {
+			serviceAccount = "default"
+		}
+		cfg.ServiceAccount = serviceAccount
+
 		cmd.CtxTimeOut(cfg.Config)
 
 		ctx := ctxlog.NewParentContext(log)
@@ -112,6 +118,10 @@ func init() {
 	pf.Int("max-workers", 1, "Maximum number of workers concurrently running the controller")
 	viper.BindPFlag("max-workers", pf.Lookup("max-workers"))
 	argToEnv["max-workers"] = "MAX_WORKERS"
+
+	pf.String("service-account", "default", "service acount for the persist output container in the created jobs")
+	viper.BindPFlag("service-account", pf.Lookup("service-account"))
+	argToEnv["service-account"] = "SERVICE_ACCOUNT"
 
 	// Add env variables to help
 	cmd.AddEnvToUsage(rootCmd, argToEnv)

--- a/deploy/helm/quarks-job/templates/operator.yaml
+++ b/deploy/helm/quarks-job/templates/operator.yaml
@@ -37,6 +37,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: SERVICE_ACCOUNT
+              value: {{ template "quarks-job.serviceAccountName" . }}
             - name: OPERATOR_NAME
               value: "quarks-job"
             - name: DOCKER_IMAGE_ORG

--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -43,6 +43,7 @@ var _ = Describe("CLI", func() {
   -l, --log-level string                  \(LOG_LEVEL\) Only print log messages from this level onward \(default "debug"\)
       --max-workers int                   \(MAX_WORKERS\) Maximum number of workers concurrently running the controller \(default 1\)
   -n, --operator-namespace string         \(OPERATOR_NAMESPACE\) The operator namespace \(default "default"\)
+      --service-account string            \(SERVICE_ACCOUNT\) service acount for the persist output container in the created jobs \(default "default"\)
       --watch-namespace string            \(WATCH_NAMESPACE\) Namespace to watch for BOSH deployments
 
 `))

--- a/integration/environment/operator.go
+++ b/integration/environment/operator.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"code.cloudfoundry.org/quarks-job/pkg/kube/operator"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	sharedcfg "code.cloudfoundry.org/quarks-utils/pkg/config"
 )
 
 // StartOperator starts the quarks job operator
@@ -45,7 +45,7 @@ func (e *Environment) setupOperator() (manager.Manager, error) {
 		return nil, errors.Errorf("required environment variable DOCKER_IMAGE_TAG not set")
 	}
 
-	err := config.SetupOperatorDockerImage(dockerImageOrg, dockerImageRepo, dockerImageTag)
+	err := sharedcfg.SetupOperatorDockerImage(dockerImageOrg, dockerImageRepo, dockerImageTag)
 	if err != nil {
 		return nil, err
 	}

--- a/integration/suite_test.go
+++ b/integration/suite_test.go
@@ -64,6 +64,11 @@ var _ = BeforeEach(func() {
 	}
 	namespacesToNuke = append(namespacesToNuke, env.Namespace)
 
+	err = env.SetupServiceAccount()
+	if err != nil {
+		fmt.Printf("WARNING: failed to setup service account: %v\n", err)
+	}
+
 	env.Stop, err = env.StartOperator()
 	if err != nil {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())

--- a/pkg/kube/controllers/controllers.go
+++ b/pkg/kube/controllers/controllers.go
@@ -8,7 +8,7 @@ import (
 
 	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
 	"code.cloudfoundry.org/quarks-job/pkg/kube/controllers/quarksjob"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-job/pkg/kube/util/config"
 )
 
 // Theses funcs construct controllers and add them to the controller-runtime

--- a/pkg/kube/controllers/quarksjob/errand_controller.go
+++ b/pkg/kube/controllers/quarksjob/errand_controller.go
@@ -19,7 +19,7 @@ import (
 
 	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
 	"code.cloudfoundry.org/quarks-job/pkg/kube/util/reference"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-job/pkg/kube/util/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
 	vss "code.cloudfoundry.org/quarks-utils/pkg/versionedsecretstore"

--- a/pkg/kube/controllers/quarksjob/errand_reconciler.go
+++ b/pkg/kube/controllers/quarksjob/errand_reconciler.go
@@ -44,7 +44,7 @@ func NewErrandReconciler(
 	f setOwnerReferenceFunc,
 	store vss.VersionedSecretStore,
 ) reconcile.Reconciler {
-	jc := NewJobCreator(mgr.GetClient(), mgr.GetScheme(), f, store)
+	jc := NewJobCreator(mgr.GetClient(), mgr.GetScheme(), f, config, store)
 
 	return &ErrandReconciler{
 		ctx:               ctx,

--- a/pkg/kube/controllers/quarksjob/errand_reconciler.go
+++ b/pkg/kube/controllers/quarksjob/errand_reconciler.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-job/pkg/kube/util/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 	"code.cloudfoundry.org/quarks-utils/pkg/meltdown"
 	vss "code.cloudfoundry.org/quarks-utils/pkg/versionedsecretstore"

--- a/pkg/kube/controllers/quarksjob/errand_reconciler_test.go
+++ b/pkg/kube/controllers/quarksjob/errand_reconciler_test.go
@@ -157,7 +157,7 @@ var _ = Describe("ErrandReconciler", func() {
 
 				It("should log create error and requeue", func() {
 					_, err := act()
-					Expect(logs.FilterMessageSnippet(fmt.Sprintf("Failed to create job '%s': could not create service account: fake-error", qJobName)).Len()).To(Equal(1))
+					Expect(logs.FilterMessageSnippet(fmt.Sprintf("Failed to create job '%s': fake-error", qJobName)).Len()).To(Equal(1))
 					Expect(err).To(HaveOccurred())
 					Expect(client.CreateCallCount()).To(Equal(1))
 				})
@@ -175,7 +175,7 @@ var _ = Describe("ErrandReconciler", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(result.Requeue).To(BeFalse())
 					Expect(logs.FilterMessageSnippet(fmt.Sprintf("Skip '%s': already running", qJobName)).Len()).To(Equal(1))
-					Expect(client.CreateCallCount()).To(Equal(3))
+					Expect(client.CreateCallCount()).To(Equal(1))
 				})
 			})
 

--- a/pkg/kube/controllers/quarksjob/errand_reconciler_test.go
+++ b/pkg/kube/controllers/quarksjob/errand_reconciler_test.go
@@ -24,8 +24,9 @@ import (
 	"code.cloudfoundry.org/quarks-job/pkg/kube/controllers"
 	"code.cloudfoundry.org/quarks-job/pkg/kube/controllers/fakes"
 	. "code.cloudfoundry.org/quarks-job/pkg/kube/controllers/quarksjob"
+	"code.cloudfoundry.org/quarks-job/pkg/kube/util/config"
 	"code.cloudfoundry.org/quarks-job/testing"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	sharedcfg "code.cloudfoundry.org/quarks-utils/pkg/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 	vss "code.cloudfoundry.org/quarks-utils/pkg/versionedsecretstore"
 	helper "code.cloudfoundry.org/quarks-utils/testing/testhelper"
@@ -73,11 +74,7 @@ var _ = Describe("ErrandReconciler", func() {
 
 		JustBeforeEach(func() {
 			ctx := ctxlog.NewParentContext(log)
-			config := &config.Config{
-				CtxTimeOut:           10 * time.Second,
-				MeltdownDuration:     config.MeltdownDuration,
-				MeltdownRequeueAfter: config.MeltdownRequeueAfter,
-			}
+			config := config.NewConfigWithTimeout(10 * time.Second)
 			reconciler = NewErrandReconciler(
 				ctx,
 				config,
@@ -258,7 +255,7 @@ var _ = Describe("ErrandReconciler", func() {
 
 					result, err := act()
 					Expect(err).ToNot(HaveOccurred())
-					Expect(result.RequeueAfter).To(Equal(config.MeltdownRequeueAfter))
+					Expect(result.RequeueAfter).To(Equal(sharedcfg.MeltdownRequeueAfter))
 				})
 
 				It("handles an error when updating job's strategy failed", func() {

--- a/pkg/kube/controllers/quarksjob/job_controller.go
+++ b/pkg/kube/controllers/quarksjob/job_controller.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-job/pkg/kube/util/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 )
 

--- a/pkg/kube/controllers/quarksjob/job_creator.go
+++ b/pkg/kube/controllers/quarksjob/job_creator.go
@@ -15,7 +15,7 @@ import (
 
 	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
 	"code.cloudfoundry.org/quarks-job/pkg/kube/util/reference"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	sharedcfg "code.cloudfoundry.org/quarks-utils/pkg/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 	"code.cloudfoundry.org/quarks-utils/pkg/names"
 	vss "code.cloudfoundry.org/quarks-utils/pkg/versionedsecretstore"
@@ -67,8 +67,8 @@ func (j jobCreatorImpl) Create(ctx context.Context, qJob qjv1a1.QuarksJob, names
 	// Create a container for persisting output
 	outputPersistContainer := corev1.Container{
 		Name:            "output-persist",
-		Image:           config.GetOperatorDockerImage(),
-		ImagePullPolicy: config.GetOperatorImagePullPolicy(),
+		Image:           sharedcfg.GetOperatorDockerImage(),
+		ImagePullPolicy: sharedcfg.GetOperatorImagePullPolicy(),
 		Args:            []string{"persist-output"},
 		Env: []corev1.EnvVar{
 			{

--- a/pkg/kube/controllers/quarksjob/job_reconciler.go
+++ b/pkg/kube/controllers/quarksjob/job_reconciler.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	qjv1a1 "code.cloudfoundry.org/quarks-job/pkg/kube/apis/quarksjob/v1alpha1"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-job/pkg/kube/util/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 	"code.cloudfoundry.org/quarks-utils/pkg/versionedsecretstore"
 )

--- a/pkg/kube/controllers/quarksjob/job_reconciler_test.go
+++ b/pkg/kube/controllers/quarksjob/job_reconciler_test.go
@@ -25,8 +25,8 @@ import (
 	"code.cloudfoundry.org/quarks-job/pkg/kube/controllers"
 	cfakes "code.cloudfoundry.org/quarks-job/pkg/kube/controllers/fakes"
 	qj "code.cloudfoundry.org/quarks-job/pkg/kube/controllers/quarksjob"
+	"code.cloudfoundry.org/quarks-job/pkg/kube/util/config"
 	"code.cloudfoundry.org/quarks-job/testing"
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 	helper "code.cloudfoundry.org/quarks-utils/testing/testhelper"
 )
@@ -81,7 +81,7 @@ var _ = Describe("ReconcileJob", func() {
 
 	JustBeforeEach(func() {
 		ctx := ctxlog.NewParentContext(log)
-		config := &config.Config{CtxTimeOut: 10 * time.Second}
+		config := config.NewConfigWithTimeout(10 * time.Second)
 		reconciler, _ = qj.NewJobReconciler(ctx, config, manager)
 		qJob, job, pod1 = env.DefaultQuarksJobWithSucceededJob("foo")
 	})

--- a/pkg/kube/operator/operator.go
+++ b/pkg/kube/operator/operator.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"code.cloudfoundry.org/quarks-utils/pkg/config"
+	"code.cloudfoundry.org/quarks-job/pkg/kube/util/config"
 	"code.cloudfoundry.org/quarks-utils/pkg/crd"
 	"code.cloudfoundry.org/quarks-utils/pkg/ctxlog"
 

--- a/pkg/kube/util/config/config.go
+++ b/pkg/kube/util/config/config.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"time"
+
+	"github.com/spf13/afero"
+
+	sharedcfg "code.cloudfoundry.org/quarks-utils/pkg/config"
+)
+
+type Config struct {
+	*sharedcfg.Config
+}
+
+// NewDefaultConfig returns a new Config for a manager of controllers
+func NewDefaultConfig(fs afero.Fs) *Config {
+	return &Config{
+		Config: &sharedcfg.Config{
+			MeltdownDuration:     sharedcfg.MeltdownDuration,
+			MeltdownRequeueAfter: sharedcfg.MeltdownRequeueAfter,
+			Fs:                   fs,
+		},
+	}
+}
+
+func NewConfigWithTimeout(timeout time.Duration) *Config {
+	return &Config{
+		Config: &sharedcfg.Config{
+			CtxTimeOut:           timeout,
+			MeltdownDuration:     sharedcfg.MeltdownDuration,
+			MeltdownRequeueAfter: sharedcfg.MeltdownRequeueAfter,
+		},
+	}
+}

--- a/pkg/kube/util/config/config.go
+++ b/pkg/kube/util/config/config.go
@@ -10,6 +10,7 @@ import (
 
 type Config struct {
 	*sharedcfg.Config
+	ServiceAccount string
 }
 
 // NewDefaultConfig returns a new Config for a manager of controllers


### PR DESCRIPTION
Use specified service account for persist-output container
    
Instead of creating a new service account with cluster admin
permissions, use the specified, pre-existing one.
The helm chart uses the same account for the operator and the
persist-output container.
    
* specify service account name on command line (SERVICE_ACCOUNT),
  defaults to 'default'
* integration tests still create their own rolebinding and service
  account
    
[#168884844](https://www.pivotaltracker.com/story/show/168884844)
