### PR TITLE
Add .Release.Namespace to helm template

### DIFF
--- a/deploy/helm/quarks-job/templates/cluster_role.yaml
+++ b/deploy/helm/quarks-job/templates/cluster_role.yaml
@@ -19,7 +19,6 @@ items:
     apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: {{ template "quarks-job.fullname" . }}
-      namespace: {{ .Release.Namespace }}
     roleRef:
       kind: ClusterRole
       name: {{ template "quarks-job.fullname" . }}

--- a/deploy/helm/quarks-job/templates/operator.yaml
+++ b/deploy/helm/quarks-job/templates/operator.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "quarks-job.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/deploy/helm/quarks-job/templates/role.yaml
+++ b/deploy/helm/quarks-job/templates/role.yaml
@@ -3,6 +3,7 @@ kind: Role
 metadata:
   creationTimestamp: null
   name: quarks-job
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
   - ""

--- a/deploy/helm/quarks-job/templates/role_binding.yaml
+++ b/deploy/helm/quarks-job/templates/role_binding.yaml
@@ -2,9 +2,11 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: quarks-job
+  namespace: {{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: quarks-job
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: quarks-job

--- a/deploy/helm/quarks-job/templates/service_account.yaml
+++ b/deploy/helm/quarks-job/templates/service_account.yaml
@@ -2,3 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "quarks-job.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
This allows for `helm template --namespace x [...] | kubectl apply -f -`.
Also, we removed the namespace in `cluster_role.yaml`, because ClusterRole is not namespaced.