### PR TITLE
Versioning: use build  separator

### DIFF
--- a/bin/build-helm
+++ b/bin/build-helm
@@ -7,7 +7,11 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 . "${GIT_ROOT}/bin/include/docker"
 
 output_dir=${GIT_ROOT}/helm
-version=$(echo "$ARTIFACT_VERSION" | sed 's/^v//')
+
+# https://semver.org/#semantic-versioning-200
+# helm does not accept ^v and considers any version with dash to be a
+# pre-release
+version=$(echo "$ARTIFACT_VERSION" | sed 's/^v//; s/-/+/')
 filename="${output_dir}/${ARTIFACT_NAME}-${version}.tgz"
 
 [ -d "${output_dir}" ] && rm -r "${output_dir}"

--- a/bin/build-helm
+++ b/bin/build-helm
@@ -20,8 +20,8 @@ cp -r "${GIT_ROOT}/deploy/helm" "${output_dir}"
 perl -pi -e "s|repository: .*|repository: ${DOCKER_IMAGE_REPOSITORY}|g" "${output_dir}/quarks-job/values.yaml"
 perl -pi -e "s|org: .*|org: ${DOCKER_IMAGE_ORG}|g" "${output_dir}/quarks-job/values.yaml"
 perl -pi -e "s|tag: .*|tag: ${DOCKER_IMAGE_TAG}|g" "${output_dir}/quarks-job/values.yaml"
-perl -pi -e "s|version: .*|version: ${version}|g" "${output_dir}/cf-operator/Chart.yaml"
-perl -pi -e "s|appVersion: .*|appVersion: ${version}|g" "${output_dir}/cf-operator/Chart.yaml"
+perl -pi -e "s|version: .*|version: ${version}|g" "${output_dir}/quarks-job/Chart.yaml"
+perl -pi -e "s|appVersion: .*|appVersion: ${version}|g" "${output_dir}/quarks-job/Chart.yaml"
 
 tar -C "${output_dir}" -czvf "${filename}" quarks-job
 

--- a/bin/include/docker
+++ b/bin/include/docker
@@ -6,11 +6,11 @@ if [ -z ${DOCKER_IMAGE_ORG+x} ]; then
 fi
 
 if [ -z ${DOCKER_IMAGE_TAG+x} ]; then
-  DOCKER_IMAGE_TAG=${ARTIFACT_VERSION}
+  DOCKER_IMAGE_TAG="$ARTIFACT_VERSION"
   export DOCKER_IMAGE_TAG
 fi
 
-if [ -z ${DOCKER_IMAGE_REPOSITORY} ]; then
+if [ -z ${DOCKER_IMAGE_REPOSITORY+x} ]; then
     DOCKER_IMAGE_REPOSITORY="quarks-job"
     export DOCKER_IMAGE_REPOSITORY
 fi

--- a/bin/include/testing
+++ b/bin/include/testing
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 function setup_testing_tmp {
-  if [ -z "${CF_OPERATOR_TESTING_TMP}" ]
+  if [ -z ${CF_OPERATOR_TESTING_TMP+x} ]
   then
     echo "[Error] Env variable \$CF_OPERATOR_TESTING_TMP is not set. Please set to continue."
     exit 1
   fi
 
+  SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP=${SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP:-}
   if [ "$SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP" != "true" ]
   then
     echo "${CF_OPERATOR_TESTING_TMP} will be cleaned up after the tests. Set SKIP_CF_OPERATOR_TESTING_TMP_CLEANUP=true to skip cleanup."

--- a/bin/include/versioning
+++ b/bin/include/versioning
@@ -1,22 +1,13 @@
 #!/bin/bash
 
-set +o errexit +o nounset
-
-test -n "${XTRACE}" && set -o xtrace
-
-set -o errexit -o nounset
-
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 GIT_DESCRIBE=$(git describe --tags --long || (git tag -a v0.0.0 -m "tag v0.0.0"; git describe --tags --long))
-GIT_BRANCH=$(git name-rev --name-only HEAD)
+GIT_BRANCH=${GIT_BRANCH:-$(git name-rev --name-only HEAD)}
 
-GIT_COMMITS=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $2 }' )
+GIT_COMMITS=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $2 }')
 GIT_SHA=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $3 }' )
-GIT_DIRTY=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $4 }' )
-GIT_TAG=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $1 }' )
-[ -z "$(git status --porcelain)" ] || GIT_TAG="${GIT_TAG}-dirty"
+GIT_TAG=$(echo "${GIT_DESCRIBE}" | awk -F - '{ print $1 }')
+[ -z "$(git status --porcelain -uno | grep -v -E '^ M (integration|e2e|docs)')" ] || GIT_TAG="${GIT_TAG}-dirty"
 
 ARTIFACT_NAME=$(basename "$(git config --get remote.origin.url)" .git)
 ARTIFACT_VERSION="${GIT_TAG}-${GIT_COMMITS}.${GIT_SHA}"
-
-set +o errexit +o nounset +o xtrace

--- a/bin/test-cli-e2e
+++ b/bin/test-cli-e2e
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
 GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/versioning"

--- a/bin/test-integration
+++ b/bin/test-integration
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eu
+set -euo pipefail
 
 GIT_ROOT="${GIT_ROOT:-$(git rev-parse --show-toplevel)}"
 . "${GIT_ROOT}/bin/include/versioning"
@@ -23,7 +23,8 @@ code.cloudfoundry.org/quarks-job/pkg/kube/operator/...,\
 code.cloudfoundry.org/quarks-job/pkg/kube/controllers/..."
 
 # Run code coverage only in CI
-if [ -n "$COVERAGE" ]; then
+COV_ARG=""
+if [ ${COVERAGE+x} ]; then
   COV_ARG="-cover -outputdir=./code-coverage  -coverprofile=${GOVER_FILE} -coverpkg ${pkgs}"
   mkdir -p code-coverage
 fi

--- a/bin/test-unit
+++ b/bin/test-unit
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 GOVER_FILE=${GOVER_FILE:-gover-unit.coverprofile}
 


### PR DESCRIPTION
Helm follows semantic versioning and considers any version with dash to
be a pre-release.  Pre-releases are not found in search unless `--devel`
is used.

[#165014706](https://www.pivotaltracker.com/story/show/165014706)