### PR TITLE
Update k8s.io/apiextensions to v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/quarks-job
 
 require (
-	code.cloudfoundry.org/quarks-utils v0.0.0-20200217102826-5c0793ae43bd
+	code.cloudfoundry.org/quarks-utils v0.0.0-20200218142826-1168643e81bc
 	github.com/onsi/ginkgo v1.10.2
 	github.com/onsi/gomega v1.6.0
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
-code.cloudfoundry.org/quarks-utils v0.0.0-20200217102826-5c0793ae43bd h1:FabuEkLnESr0HpmqhLzS6IS6UiN1zKd3Rpvz3hH2onw=
-code.cloudfoundry.org/quarks-utils v0.0.0-20200217102826-5c0793ae43bd/go.mod h1:d2OaSM1qVE/7Zo1imovL7CZCOAShFePFMI3jlpMcp14=
+code.cloudfoundry.org/quarks-utils v0.0.0-20200218142826-1168643e81bc h1:YsWai+sFwe8kD2MywusQbf2bXshQP99u7K0n7ofDBfg=
+code.cloudfoundry.org/quarks-utils v0.0.0-20200218142826-1168643e81bc/go.mod h1:d2OaSM1qVE/7Zo1imovL7CZCOAShFePFMI3jlpMcp14=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=

--- a/pkg/kube/apis/quarksjob/v1alpha1/register.go
+++ b/pkg/kube/apis/quarksjob/v1alpha1/register.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/kube/apis/quarksjob/v1alpha1/register.go
+++ b/pkg/kube/apis/quarksjob/v1alpha1/register.go
@@ -95,6 +95,14 @@ var (
 						},
 					},
 				},
+				"status": {
+					Type: "object",
+					Properties: map[string]extv1.JSONSchemaProps{
+						"lastReconcile": {
+							Type: "object",
+						},
+					},
+				},
 			},
 		},
 	}

--- a/pkg/kube/apis/quarksjob/v1alpha1/types.go
+++ b/pkg/kube/apis/quarksjob/v1alpha1/types.go
@@ -106,7 +106,6 @@ type Output struct {
 // QuarksJobStatus defines the observed state of QuarksJob
 type QuarksJobStatus struct {
 	LastReconcile *metav1.Time `json:"lastReconcile"`
-	Nodes         []string     `json:"nodes"`
 }
 
 // +genclient

--- a/pkg/kube/apis/quarksjob/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/kube/apis/quarksjob/v1alpha1/zz_generated.deepcopy.go
@@ -198,11 +198,6 @@ func (in *QuarksJobStatus) DeepCopyInto(out *QuarksJobStatus) {
 		in, out := &in.LastReconcile, &out.LastReconcile
 		*out = (*in).DeepCopy()
 	}
-	if in.Nodes != nil {
-		in, out := &in.Nodes, &out.Nodes
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	return
 }
 

--- a/pkg/kube/client/clientset/versioned/clientset.go
+++ b/pkg/kube/client/clientset/versioned/clientset.go
@@ -48,7 +48,7 @@ func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
 		if configShallowCopy.Burst <= 0 {
-			return nil, fmt.Errorf("burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
+			return nil, fmt.Errorf("Burst is required to be greater than 0 when RateLimiter is not set and QPS is set to greater than 0")
 		}
 		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
 	}

--- a/pkg/kube/operator/operator.go
+++ b/pkg/kube/operator/operator.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	extv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	extv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 


### PR DESCRIPTION
CRDs are GA in Kubernetes 1.16



**Forgot to make this a DRAFT PR, don't merge yet**