### PR TITLE
Switch OS to SLE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY . .
 RUN bin/build && \
     cp -p binaries/quarks-job /usr/local/bin/quarks-job
 
-FROM cfcontainerization/cf-operator-base
+FROM registry.opensuse.org/cloud/platform/quarks/sle_15_sp1/quarks-operator-base:latest
 RUN groupadd -g 1000 quarks && \
     useradd -r -u 1000 -g quarks quarks
 USER quarks


### PR DESCRIPTION
Docker base image is built on [OBS](https://build.opensuse.org/package/show/Cloud:Platform:quarks/quarks-operator-base).

[#171779755](https://www.pivotaltracker.com/story/show/171779755)