### PR TITLE
Publish helm release on github repo instead of s3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,14 +117,12 @@ jobs:
       - ./bin/build-helm
       - mkdir helm-charts
       - cp helm/quarks-job*.tgz helm-charts/
+      - git tag -a $ARTIFACT_VERSION -m "tag $ARTIFACT_VERSION"
       deploy:
-        provider: s3
-        access_key_id: "${AWS_ACCESS_KEY}"
-        secret_access_key: "${AWS_SECRET_KEY}"
-        bucket: "${S3_BUCKET}"
-        acl: public_read
+      - provider: releases
+        api_key: $GITHUB_TOKEN
+        file_glob: true
+        file: "helm-charts/quarks-job*.tgz"
         skip_cleanup: true
-        local_dir: helm-charts
-        upload_dir: helm-charts
         on:
           branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,11 @@ jobs:
       - cp helm/quarks-job*.tgz helm-charts/
       - git tag -a $ARTIFACT_VERSION -m "tag $ARTIFACT_VERSION"
       deploy:
+      - provider: script
+        script: git clone https://CFContainerizationBot:$GITHUB_TOKEN@github.com/cloudfoundry-incubator/quarks-helm.git ./updated/ && cp helm-charts/quarks-job*.tgz updated/ && ./bin/publish-helm-repo
+        skip_cleanup: true
+        on:
+          branch: master
       - provider: releases
         api_key: $GITHUB_TOKEN
         file_glob: true

--- a/bin/publish-helm-repo
+++ b/bin/publish-helm-repo
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -v
+
+version=$ARTIFACT_VERSION
+
+pushd updated
+  helm repo index .
+  git add .
+  git config --global user.name "CFContainerizationBot"
+  git config --global user.email "cfcontainerizationbot@cloudfoundry.org"
+  git commit -m "add quarks-job chart: $version"
+  git push
+popd


### PR DESCRIPTION
[#171492037](https://www.pivotaltracker.com/story/show/171492037)

- Published helm release to https://github.com/cloudfoundry-incubator/quarks-helm and quarks-job release page on master branch