### PR TITLE
Remove github releases publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ cache:
 services:
 - docker
 
+git:
+  depth: false
+
 env:
   global:
     - GOPROXY="https://proxy.golang.org"
@@ -113,21 +116,18 @@ jobs:
         - sudo ./get_helm.sh
       script: echo "Publishing helm chart"
       before_deploy:
-      - . bin/include/versioning
-      - ./bin/build-helm
-      - mkdir helm-charts
-      - cp helm/quarks-job*.tgz helm-charts/
-      - git tag -a $ARTIFACT_VERSION -m "tag $ARTIFACT_VERSION"
+        - . bin/include/versioning
+        - ./bin/build-helm
+        - mkdir helm-charts
+        - cp helm/quarks-job*.tgz helm-charts/
+        - git tag -a $ARTIFACT_VERSION -m "tag $ARTIFACT_VERSION"
+        - export ARTIFACT_VERSION=$ARTIFACT_VERSION
       deploy:
-      - provider: script
-        script: git clone https://CFContainerizationBot:$GITHUB_TOKEN@github.com/cloudfoundry-incubator/quarks-helm.git ./updated/ && cp helm-charts/quarks-job*.tgz updated/ && ./bin/publish-helm-repo
-        skip_cleanup: true
-        on:
-          branch: master
-      - provider: releases
-        api_key: $GITHUB_TOKEN
-        file_glob: true
-        file: "helm-charts/quarks-job*.tgz"
-        skip_cleanup: true
-        on:
-          branch: master
+        - provider: script
+          script:
+            git clone https://CFContainerizationBot:$GITHUB_TOKEN@github.com/cloudfoundry-incubator/quarks-helm.git ./updated/ &&
+            cp helm-charts/quarks-job*.tgz updated/ &&
+            ./bin/publish-helm-repo
+          skip_cleanup: true
+          on:
+            branch: master

--- a/bin/publish-helm-repo
+++ b/bin/publish-helm-repo
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -v
 
 version=$ARTIFACT_VERSION
 


### PR DESCRIPTION
Found a travis limit that `before_deploy runs for each deploy`: https://github.com/travis-ci/travis-ci/issues/2570#issuecomment-171262181

Even used that workaround, it still could not save helm artifacts between two deploys.

