### PR TITLE
Remove Entanglement code from Quarks Job

### DIFF
--- a/pkg/kube/apis/quarksjob/v1alpha1/types.go
+++ b/pkg/kube/apis/quarksjob/v1alpha1/types.go
@@ -150,24 +150,26 @@ func (q *QuarksJob) GetNamespacedName() string {
 }
 
 // NewFileToSecret returns a FilesToSecrets with just one mapping
-func NewFileToSecret(fileName string, secretName string, versioned bool) FilesToSecrets {
+func NewFileToSecret(fileName string, secretName string, versioned bool, additionalLabels map[string]string) FilesToSecrets {
 	return FilesToSecrets{
 		fileName: SecretOptions{
-			Name:              secretName,
-			Versioned:         versioned,
-			PersistenceMethod: PersistOneToOne,
+			Name:                   secretName,
+			Versioned:              versioned,
+			PersistenceMethod:      PersistOneToOne,
+			AdditionalSecretLabels: additionalLabels,
 		},
 	}
 }
 
 // NewFileToSecrets uses a fan out style and creates one secret per key/value
 // pair in the given input file
-func NewFileToSecrets(fileName string, secretName string, versioned bool) FilesToSecrets {
+func NewFileToSecrets(fileName string, secretName string, versioned bool, additionalLabels map[string]string) FilesToSecrets {
 	return FilesToSecrets{
 		fileName: SecretOptions{
-			Name:              secretName,
-			Versioned:         versioned,
-			PersistenceMethod: PersistUsingFanOut,
+			Name:                   secretName,
+			Versioned:              versioned,
+			PersistenceMethod:      PersistUsingFanOut,
+			AdditionalSecretLabels: additionalLabels,
 		},
 	}
 }

--- a/pkg/kube/apis/quarksjob/v1alpha1/types.go
+++ b/pkg/kube/apis/quarksjob/v1alpha1/types.go
@@ -27,9 +27,6 @@ var (
 	LabelQJobName = fmt.Sprintf("%s/qjob-name", apis.GroupName)
 	// LabelTriggeringPod key for label, which is set to the UID of the pod that triggered an QuarksJob
 	LabelTriggeringPod = fmt.Sprintf("%s/triggering-pod", apis.GroupName)
-
-	// LabelEntanglementKey to identify a quarks link
-	LabelEntanglementKey = fmt.Sprintf("%s/entanglement", apis.GroupName)
 )
 
 // QuarksJobSpec defines the desired state of QuarksJob

--- a/pkg/kube/controllers/quarksjob/output_persistor.go
+++ b/pkg/kube/controllers/quarksjob/output_persistor.go
@@ -148,22 +148,20 @@ func (po *OutputPersistor) persistContainer(
 					po.log.Debugf("container '%s': creating secrets with prefix '%s' from '%s'", container.Name, options.Name, filePath)
 					for key, value := range data {
 						secretName := options.FanOutName(key)
-						options.AdditionalSecretLabels[qjv1a1.LabelEntanglementKey] = secretName
 
 						var secretData map[string]string
 						if err := json.Unmarshal([]byte(value), &secretData); err != nil {
 							errorContainerChannel <- err
 						}
 
-						if err := po.createSecret(ctx, qJob, container, secretName, secretData, options.AdditionalSecretLabels, options.Versioned); err != nil {
+						if err := po.createSecret(ctx, qJob, container, secretName, secretData, map[string]string{}, options.Versioned); err != nil {
 							errorContainerChannel <- err
 						}
 					}
 
 				default:
 					po.log.Debugf("container '%s': creating secret '%s' from '%s'", container.Name, options.Name, filePath)
-					options.AdditionalSecretLabels[qjv1a1.LabelEntanglementKey] = options.Name
-					if err := po.createSecret(ctx, qJob, container, options.Name, data, options.AdditionalSecretLabels, options.Versioned); err != nil {
+					if err := po.createSecret(ctx, qJob, container, options.Name, data, map[string]string{}, options.Versioned); err != nil {
 						errorContainerChannel <- err
 					}
 				}

--- a/pkg/kube/controllers/quarksjob/output_persistor.go
+++ b/pkg/kube/controllers/quarksjob/output_persistor.go
@@ -154,14 +154,14 @@ func (po *OutputPersistor) persistContainer(
 							errorContainerChannel <- err
 						}
 
-						if err := po.createSecret(ctx, qJob, container, secretName, secretData, map[string]string{}, options.Versioned); err != nil {
+						if err := po.createSecret(ctx, qJob, container, secretName, secretData, options.AdditionalSecretLabels, options.Versioned); err != nil {
 							errorContainerChannel <- err
 						}
 					}
 
 				default:
 					po.log.Debugf("container '%s': creating secret '%s' from '%s'", container.Name, options.Name, filePath)
-					if err := po.createSecret(ctx, qJob, container, options.Name, data, map[string]string{}, options.Versioned); err != nil {
+					if err := po.createSecret(ctx, qJob, container, options.Name, data, options.AdditionalSecretLabels, options.Versioned); err != nil {
 						errorContainerChannel <- err
 					}
 				}

--- a/pkg/kube/controllers/quarksjob/output_persistor_test.go
+++ b/pkg/kube/controllers/quarksjob/output_persistor_test.go
@@ -94,12 +94,15 @@ var _ = Describe("OutputPersistor", func() {
 
 			Context("when output persistence is configured", func() {
 				BeforeEach(func() {
+					additionalLabels := map[string]string{
+						"quarks.cloudfoundry.org/entanglement": "foo-busybox",
+					}
 					qJob.Spec.Output = &qjv1a1.Output{
 						SecretLabels: map[string]string{
 							"key": "value",
 						},
 						OutputMap: qjv1a1.OutputMap{
-							"busybox": qjv1a1.NewFileToSecret("output.json", "foo-busybox", false),
+							"busybox": qjv1a1.NewFileToSecret("output.json", "foo-busybox", false, additionalLabels),
 						},
 					}
 				})
@@ -117,6 +120,9 @@ var _ = Describe("OutputPersistor", func() {
 			})
 
 			Context("when versioned output is enabled", func() {
+				additionalLabels := map[string]string{
+					"quarks.cloudfoundry.org/entanglement": "foo-busybox",
+				}
 				BeforeEach(func() {
 					qJob.Spec.Output = &qjv1a1.Output{
 						SecretLabels: map[string]string{
@@ -126,8 +132,9 @@ var _ = Describe("OutputPersistor", func() {
 						OutputMap: qjv1a1.OutputMap{
 							"busybox": qjv1a1.FilesToSecrets{
 								"output.json": qjv1a1.SecretOptions{
-									Name:      "foo-busybox",
-									Versioned: true,
+									Name:                   "foo-busybox",
+									Versioned:              true,
+									AdditionalSecretLabels: additionalLabels,
 								},
 							},
 						},
@@ -263,7 +270,7 @@ var _ = Describe("OutputPersistor", func() {
 				BeforeEach(func() {
 					qJob.Spec.Output = &qjv1a1.Output{
 						OutputMap: qjv1a1.OutputMap{
-							"busybox": qjv1a1.NewFileToSecrets("provides.json", "link-nats-deployment", false),
+							"busybox": qjv1a1.NewFileToSecrets("provides.json", "link-nats-deployment", false, map[string]string{}),
 						},
 					}
 

--- a/pkg/kube/controllers/quarksjob/output_persistor_test.go
+++ b/pkg/kube/controllers/quarksjob/output_persistor_test.go
@@ -119,11 +119,10 @@ var _ = Describe("OutputPersistor", func() {
 				})
 
 				Context("when the output file is not json valid", func() {
-
 					BeforeEach(func() {
 						// Create faulty output file
-						dataJSON = []byte("{\"hello\"= \"world\"}")
-						err := ioutil.WriteFile(filepath.Join(tmpDir, "busybox", "faultyoutput.json"), dataJSON, 0755)
+						faultydataJSON := []byte("{\"hello\"= \"world\"}")
+						err := ioutil.WriteFile(filepath.Join(tmpDir, "busybox", "faultyoutput.json"), faultydataJSON, 0755)
 						Expect(err).NotTo(HaveOccurred())
 
 						qJob.Spec.Output.OutputMap = qjv1a1.OutputMap{
@@ -210,6 +209,10 @@ var _ = Describe("OutputPersistor", func() {
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})
+		})
+
+		AfterEach(func() {
+			Expect(os.RemoveAll(tmpDir)).ToNot(HaveOccurred())
 		})
 	})
 
@@ -326,6 +329,9 @@ var _ = Describe("OutputPersistor", func() {
 
 		Context("With a failed Job", func() {
 			BeforeEach(func() {
+				err := ioutil.WriteFile(filepath.Join(tmpDir, "busybox", "output.json"), dataJSON, 0755)
+				Expect(err).NotTo(HaveOccurred())
+
 				pod.Status.ContainerStatuses = []corev1.ContainerStatus{
 					{
 						Name: "busybox",
@@ -354,6 +360,10 @@ var _ = Describe("OutputPersistor", func() {
 					_, err = clientSet.CoreV1().Secrets(namespace).Get(context.Background(), "bar-nuts-v1", metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred())
 				})
+			})
+
+			AfterEach(func() {
+				Expect(os.RemoveAll(tmpDir)).ToNot(HaveOccurred())
 			})
 		})
 	})


### PR DESCRIPTION
[#172404604](https://www.pivotaltracker.com/n/projects/2192232/stories/172404604)

I think we should not put entanglement logic inside QuarksJob since it is not the feature of QuarksJob

Part of https://github.com/cloudfoundry-incubator/cf-operator/pull/909