### PR TITLE
Configurable Meltdown

### DIFF
--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -61,6 +61,7 @@ var rootCmd = &cobra.Command{
 		cfg.ServiceAccount = serviceAccount
 
 		cmd.CtxTimeOut(cfg.Config)
+		cmd.Meltdown(cfg.Config)
 
 		ctx := ctxlog.NewParentContext(log)
 
@@ -113,6 +114,7 @@ func init() {
 	cmd.WatchNamespaceFlags(pf, argToEnv)
 	cmd.DockerImageFlags(pf, argToEnv, "quarks-job", version.Version)
 	cmd.ApplyCRDsFlags(pf, argToEnv)
+	cmd.MeltdownFlags(pf, argToEnv)
 
 	pf.Int("max-workers", 1, "Maximum number of workers concurrently running the controller")
 	viper.BindPFlag("max-workers", pf.Lookup("max-workers"))

--- a/cmd/internal/root.go
+++ b/cmd/internal/root.go
@@ -26,7 +26,7 @@ import (
 var log *zap.SugaredLogger
 
 func wrapError(err error, msg string) error {
-	return errors.Wrap(err, "quarks-job command failed. "+msg)
+	return errors.Wrapf(err, "quarks-job command failed. %s", msg)
 }
 
 var rootCmd = &cobra.Command{

--- a/deploy/helm/quarks-job/templates/operator.yaml
+++ b/deploy/helm/quarks-job/templates/operator.yaml
@@ -34,6 +34,10 @@ spec:
               value: "{{ .Values.global.operator.watchNamespace }}"
             - name: CTX_TIMEOUT
               value: "{{ .Values.global.contextTimeout }}"
+            - name: MELTDOWN_DURATION
+              value: "{{ .Values.global.meltdownDuration }}"
+            - name: MELTDOWN_REQUEUE_AFTER
+              value: "{{ .Values.global.meltdownRequeueAfter }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/helm/quarks-job/values.yaml
+++ b/deploy/helm/quarks-job/values.yaml
@@ -39,6 +39,11 @@ serviceAccount:
 global:
   # contextTimeout is the timeout value for each K8's API request in seconds.
   contextTimeout: 30
+  # MeltdownDuration is the duration (in seconds) of the meltdown period, in which we
+  # postpone further reconciles for the same resource
+  meltdownDuration: 60
+  # MeltdownRequeueAfter is the duration (in seconds) for which we delay the requeuing of the reconcile
+  meltdownRequeueAfter: 30
   rbac:
     # create is a boolean to control the installation of rbac resources.
     create: true

--- a/e2e/cli/cli_test.go
+++ b/e2e/cli/cli_test.go
@@ -42,6 +42,8 @@ var _ = Describe("CLI", func() {
   -c, --kubeconfig string                 \(KUBECONFIG\) Path to a kubeconfig, not required in-cluster
   -l, --log-level string                  \(LOG_LEVEL\) Only print log messages from this level onward \(trace,debug,info,warn\) \(default "debug"\)
       --max-workers int                   \(MAX_WORKERS\) Maximum number of workers concurrently running the controller \(default 1\)
+      --meltdown-duration int             \(MELTDOWN_DURATION\) Duration \(in seconds\) of the meltdown period, in which we postpone further reconciles for the same resource \(default 60\)
+      --meltdown-requeue-after int        \(MELTDOWN_REQUEUE_AFTER\) Duration \(in seconds\) for which we delay the requeuing of the reconcile \(default 30\)
       --service-account string            \(SERVICE_ACCOUNT\) service acount for the persist output container in the created jobs \(default "default"\)
   -a, --watch-namespace string            \(WATCH_NAMESPACE\) Act on this namespace, watch for BOSH deployments and create resources \(default "staging"\)
 

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/quarks-job
 
 require (
-	code.cloudfoundry.org/quarks-utils v0.0.0-20200426163230-480b21a17497
+	code.cloudfoundry.org/quarks-utils v0.0.0-20200430060231-bc368dd626a3
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.8.1
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,9 @@ code.cloudfoundry.org/quarks-utils v0.0.0-20200331122601-bc0838ffea60 h1:1FNLU6z
 code.cloudfoundry.org/quarks-utils v0.0.0-20200331122601-bc0838ffea60/go.mod h1:d2OaSM1qVE/7Zo1imovL7CZCOAShFePFMI3jlpMcp14=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200426163230-480b21a17497 h1:rjWCSxXWx6fC7F5FthKHxaovbjm8IPA/YK5ct4XG0Qo=
 code.cloudfoundry.org/quarks-utils v0.0.0-20200426163230-480b21a17497/go.mod h1:MxdilS/wL1D5NokUPCGR3AX1PqCwCQc+ex8Jk87lbgU=
+code.cloudfoundry.org/quarks-utils v0.0.0-20200428112510-6e74eab76024 h1:2PTW5ID29CXm0E0tcF2RpTd1BcISnDdfK6KqlTLEACc=
+code.cloudfoundry.org/quarks-utils v0.0.0-20200428112510-6e74eab76024/go.mod h1:MxdilS/wL1D5NokUPCGR3AX1PqCwCQc+ex8Jk87lbgU=
+code.cloudfoundry.org/quarks-utils v0.0.0-20200430060231-bc368dd626a3/go.mod h1:MxdilS/wL1D5NokUPCGR3AX1PqCwCQc+ex8Jk87lbgU=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest/autorest v0.9.0/go.mod h1:xyHB1BMZT0cuDHU7I0+g046+BFDTQ8rEZB0s4Yfa6bI=
 github.com/Azure/go-autorest/autorest/adal v0.5.0/go.mod h1:8Z9fGy2MpX0PvDjB1pEgQTmVqjGhiHBW7RJJEciWzS0=

--- a/pkg/kube/util/config/config.go
+++ b/pkg/kube/util/config/config.go
@@ -17,11 +17,7 @@ type Config struct {
 // NewDefaultConfig returns a new Config for a manager of controllers
 func NewDefaultConfig(fs afero.Fs) *Config {
 	return &Config{
-		Config: &sharedcfg.Config{
-			MeltdownDuration:     sharedcfg.MeltdownDuration,
-			MeltdownRequeueAfter: sharedcfg.MeltdownRequeueAfter,
-			Fs:                   fs,
-		},
+		Config: sharedcfg.NewDefaultConfig(fs),
 	}
 }
 


### PR DESCRIPTION
Allows to set meltdown from CLI and helm chart
Requires https://github.com/cloudfoundry-incubator/quarks-utils/pull/42

[#170670255](https://www.pivotaltracker.com/story/show/170670255)
