### PR TITLE
Fix development version by unshallowing git repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,13 +87,14 @@ jobs:
       install: []
       script: echo "Publishing helm chart"
       before_deploy:
+        - git fetch --unshallow
         - . bin/include/versioning
         - ./bin/build-helm
         - mkdir helm-charts
         - cp -a helm/quarks-job*.tgz helm-charts/
         - git tag -a $ARTIFACT_VERSION -m "tag $ARTIFACT_VERSION"
         - git push --quiet https://CFContainerizationBot:$GITHUB_TOKEN@github.com/cloudfoundry-incubator/quarks-job.git $ARTIFACT_VERSION > /dev/null 2>&1
-        - export ARTIFACT_VERSION=$ARTIFACT_VERSION
+        - export ARTIFACT_VERSION
       deploy:
         - provider: script
           script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,41 +77,31 @@ jobs:
       name: unit
       env: KUBE=none
 
-    - stage: Publishing docker image
+    - stage: Publishing
       # security: only on master, or if PR repo is our repo
       if: branch = master OR (type = pull_request AND head_repo = repo)
       # do not inherit
       install: []
       before_script: []
-      script: echo "Publishing docker image"
-      deploy:
-        provider: script
-        script: bash -c "make publish-image"
-        skip_cleanup: true
-        on:
-          branch: master
-
-    - stage: Publishing helm chart
-      # security: only on master, or if PR repo is our repo
-      if: branch = master OR (type = pull_request AND head_repo = repo)
-      # do not inherit
-      install: []
-      script: echo "Publishing helm chart"
+      script: echo "Publishing"
       before_deploy:
         - git fetch --unshallow
         - . bin/include/versioning
-        - ./bin/build-helm
-        - mkdir helm-charts
-        - cp -a helm/quarks-job*.tgz helm-charts/
-        - git tag -a $ARTIFACT_VERSION -m "tag $ARTIFACT_VERSION"
-        - git push --quiet https://CFContainerizationBot:$GITHUB_TOKEN@github.com/cloudfoundry-incubator/quarks-job.git $ARTIFACT_VERSION > /dev/null 2>&1
-        - export ARTIFACT_VERSION
       deploy:
         - provider: script
           script:
-            git clone https://CFContainerizationBot:$GITHUB_TOKEN@github.com/cloudfoundry-incubator/quarks-helm.git ./updated/ &&
-            cp -a helm-charts/quarks-job*.tgz updated/ &&
-            ./bin/publish-helm-repo
-          skip_cleanup: true
-          on:
-            branch: master
+            - bin/build-image
+            - bin/publish-image
+
+        - provider: script
+          script:
+            - ./bin/build-helm
+            - |
+              git clone https://CFContainerizationBot:$GITHUB_TOKEN@github.com/cloudfoundry-incubator/quarks-helm.git ./updated/ &&
+              cp -a helm/quarks-job*.tgz updated/ &&
+              ./bin/publish-helm-repo
+
+        - provider: script
+          script:
+            - git tag -a $ARTIFACT_VERSION -m "tag $ARTIFACT_VERSION"
+            - git push --quiet https://CFContainerizationBot:$GITHUB_TOKEN@github.com/cloudfoundry-incubator/quarks-job.git $ARTIFACT_VERSION > /dev/null 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,6 +102,7 @@ jobs:
               ./bin/publish-helm-repo
 
         - provider: script
+          if: branch = master AND type = push
           script:
             - git tag -a $ARTIFACT_VERSION -m "tag $ARTIFACT_VERSION"
             - git push --quiet https://CFContainerizationBot:$GITHUB_TOKEN@github.com/cloudfoundry-incubator/quarks-job.git $ARTIFACT_VERSION > /dev/null 2>&1

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ stages:
   - unit
   - test
 
+# Avoid too many builds, works for PRs too, as this is also their base branch.
+# Otherwise opening a PR from a branch would trigger two builds.
+branches:
+  only:
+  - master
+
 install:
   # Download go dev dependencies
   - export PATH=$PATH:$GOPATH/bin
@@ -33,6 +39,8 @@ install:
   - go get github.com/mattn/goveralls
   - go get github.com/modocache/gover
 
+
+# The matrix build for all Kubernetes versions
 before_script:
   # Download and install kubectl
   - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
@@ -51,6 +59,7 @@ script:
   - USE_KIND="true" make test-cluster
   - make coverage
 
+# These steps are run outside the matrix
 jobs:
   include:
     - stage: unit
@@ -68,12 +77,13 @@ jobs:
       name: unit
       env: KUBE=none
 
-    - stage: Publishing image
-      if: branch = master
+    - stage: Publishing docker image
+      # security: only on master, or if PR repo is our repo
+      if: branch = master OR (type = pull_request AND head_repo = repo)
       # do not inherit
       install: []
       before_script: []
-      script: echo "Publishing image"
+      script: echo "Publishing docker image"
       deploy:
         provider: script
         script: bash -c "make publish-image"
@@ -82,7 +92,8 @@ jobs:
           branch: master
 
     - stage: Publishing helm chart
-      if: branch = master
+      # security: only on master, or if PR repo is our repo
+      if: branch = master OR (type = pull_request AND head_repo = repo)
       # do not inherit
       install: []
       script: echo "Publishing helm chart"

--- a/bin/include/docker
+++ b/bin/include/docker
@@ -11,6 +11,6 @@ if [ -z ${DOCKER_IMAGE_TAG+x} ]; then
 fi
 
 if [ -z ${DOCKER_IMAGE_REPOSITORY+x} ]; then
-    DOCKER_IMAGE_REPOSITORY="quarks-job"
-    export DOCKER_IMAGE_REPOSITORY
+  DOCKER_IMAGE_REPOSITORY="quarks-job"
+  export DOCKER_IMAGE_REPOSITORY
 fi

--- a/bin/include/versioning
+++ b/bin/include/versioning
@@ -1,4 +1,21 @@
 #!/bin/bash
 
+TRAVIS_PULL_REQUEST=${TRAVIS_PULL_REQUEST-}
+TRAVIS_COMMIT=${TRAVIS_COMMIT-}
 COMMIT_NUMBER=$(git rev-list --first-parent --count HEAD)
-ARTIFACT_VERSION="v0.0.${COMMIT_NUMBER}"
+
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  # travis is building on master
+  ARTIFACT_VERSION="v1.0.$COMMIT_NUMBER"
+
+elif [ -n "${TRAVIS_PULL_REQUEST:-}" ]; then
+  # this is running on a travis PR
+  ARTIFACT_VERSION="v0.0.$TRAVIS_PULL_REQUEST-g$TRAVIS_COMMIT"
+
+else
+  # this is not running in travis
+  COMMIT=$(git describe --tags --long | awk -F - '{ print $NF }')
+  ARTIFACT_VERSION="v0.0.$COMMIT_NUMBER-$COMMIT"
+fi
+
+export ARTIFACT_VERSION

--- a/bin/include/versioning
+++ b/bin/include/versioning
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-COMMIT_NUMBER=$(git rev-list --count HEAD)
+COMMIT_NUMBER=$(git rev-list --first-parent --count HEAD)
 ARTIFACT_VERSION="v0.0.${COMMIT_NUMBER}"

--- a/bin/publish-helm-repo
+++ b/bin/publish-helm-repo
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 version=$ARTIFACT_VERSION
 
 pushd updated


### PR DESCRIPTION
Using `rev-list --count` gave us version 77 instead of 1176, or 92 instead of 1190.
We also had duplicate version numbers in separate PRs.
Travis creates a shallow git clone, so we unshallow it before counting
commits. We also add '--first-parent' for robustness.

[#172599056](https://www.pivotaltracker.com/story/show/172599056)