### PR TITLE
Fix build-helm.sh issue with Helm 3.5

### DIFF
--- a/deploy/helm/quarks-job/Chart.yaml
+++ b/deploy/helm/quarks-job/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: quarks-job
-version: x.x.x
-appVersion: x.x.x
+version: 0.0.0
+appVersion: 0.0.0
 description: A Helm chart for quarks-job, a k8s operator for quarks jobs
 home: https://github.com/cloudfoundry-incubator/quarks-job
 icon: https://cloudfoundry-incubator.github.io/quarks-helm/logo.png


### PR DESCRIPTION
As described here helm/helm#9298 the invalid
string no longer works.