### PR TITLE
Use namespace to generate Release.fullname

### DIFF
--- a/deploy/helm/quarks-job/templates/_helpers.tpl
+++ b/deploy/helm/quarks-job/templates/_helpers.tpl
@@ -16,8 +16,8 @@ If release name contains chart name it will be used as a full name.
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- if contains $name .Release.Name -}}
-{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- if contains $name .Release.Namespace -}}
+{{- .Release.Namespace | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -36,7 +36,7 @@ Create the name of the quarks-job service account to use
 */}}
 {{- define "quarks-job.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "quarks-job.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "quarks-job.name" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/deploy/helm/quarks-job/templates/operator.yaml
+++ b/deploy/helm/quarks-job/templates/operator.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "quarks-job.fullname" . }}
+  name: {{ template "quarks-job.name" . }}
   namespace: "{{ .Release.Namespace }}"
 spec:
   replicas: 1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module code.cloudfoundry.org/quarks-job
 
 require (
-	code.cloudfoundry.org/quarks-utils v0.0.2-0.20210225151037-f17676b0c328
+	code.cloudfoundry.org/quarks-utils v0.0.2
 	github.com/go-logr/logr v0.3.0
 	github.com/mitchellh/mapstructure v1.3.2 // indirect
 	github.com/onsi/ginkgo v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIA
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0ZeosJ0Rtdos=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
+code.cloudfoundry.org/quarks-utils v0.0.2 h1:ONFYFBKo4saNKdTo8StcYo/71+3skCoj0fIakInHnbY=
+code.cloudfoundry.org/quarks-utils v0.0.2/go.mod h1:chUN4PKXqnLDSe6zkUvmR5RnjysI87arFtDME1xHP/k=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=


### PR DESCRIPTION
Also reduce the other names, only prefix cluster-wide resources with
fullname.

[#175984792](https://www.pivotaltracker.com/story/show/175984792)