### PR TITLE
Enable affinity configuration to schedule pod on specific nodes in cluster

### DIFF
--- a/deploy/helm/quarks-job/README.md
+++ b/deploy/helm/quarks-job/README.md
@@ -72,7 +72,7 @@ $ helm delete quarks-job --purge
 | `serviceAccount.name`                             | If not set and `create` is `true`, a name is generated using the fullname of the chart |                                                |
 | `global.singleNamespace.create`                   | If true, create a service account and a single watch namespace                         | `true`                                         |
 | `global.singleNamespace.name`                     | Namespace the operator will watch for Quarks jobs                                      | `staging`                                      |
-
+| `affinity`                     |  Scheduling pod on specicifc nodes by adding lables to nodes                                      | `affinity`                                      |
 ## RBAC
 
 By default, the helm chart will install RBAC ClusterRole and ClusterRoleBinding based on the chart release name, it will also grant the ClusterRole to an specific service account, which have the same name of the chart release.

--- a/deploy/helm/quarks-job/README.md
+++ b/deploy/helm/quarks-job/README.md
@@ -72,7 +72,7 @@ $ helm delete quarks-job --purge
 | `serviceAccount.name`                             | If not set and `create` is `true`, a name is generated using the fullname of the chart |                                                |
 | `global.singleNamespace.create`                   | If true, create a service account and a single watch namespace                         | `true`                                         |
 | `global.singleNamespace.name`                     | Namespace the operator will watch for Quarks jobs                                      | `staging`                                      |
-| `affinity`                     |  Scheduling pod on specicifc nodes by adding lables to nodes                                      | `affinity`                                      |
+| `affinity`                     |  Scheduling pod on specicifc nodes by adding labels to nodes                                      | `affinity`                                      |
 ## RBAC
 
 By default, the helm chart will install RBAC ClusterRole and ClusterRoleBinding based on the chart release name, it will also grant the ClusterRole to an specific service account, which have the same name of the chart release.

--- a/deploy/helm/quarks-job/templates/operator.yaml
+++ b/deploy/helm/quarks-job/templates/operator.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         name: quarks-job
     spec:
+      {{- if .Values.affinity }}
+      affinity: {{ .Values.affinity | toJson }}
+      {{- end }}
       serviceAccountName: {{ template "quarks-job.serviceAccountName" . }}
       containers:
         - name: quarks-job

--- a/deploy/helm/quarks-job/values.yaml
+++ b/deploy/helm/quarks-job/values.yaml
@@ -74,4 +74,5 @@ global:
     create: true
     # name is  the name of the single namespace.
     name: staging
+    # Scheduling pod on specicifc nodes by adding labels to nodes
 affinity: {}

--- a/deploy/helm/quarks-job/values.yaml
+++ b/deploy/helm/quarks-job/values.yaml
@@ -74,3 +74,4 @@ global:
     create: true
     # name is  the name of the single namespace.
     name: staging
+affinity:

--- a/deploy/helm/quarks-job/values.yaml
+++ b/deploy/helm/quarks-job/values.yaml
@@ -74,4 +74,4 @@ global:
     create: true
     # name is  the name of the single namespace.
     name: staging
-affinity:
+affinity: {}

--- a/deploy/helm/quarks-job/values.yaml
+++ b/deploy/helm/quarks-job/values.yaml
@@ -74,5 +74,15 @@ global:
     create: true
     # name is  the name of the single namespace.
     name: staging
-    # Scheduling pod on specicifc nodes by adding labels to nodes
+# Scheduling pod on specific nodes by adding labels to nodes
+# Example
+# affinity:
+#   nodeAffinity:
+#     requiredDuringSchedulingIgnoredDuringExecution:
+#       nodeSelectorTerms:
+#       - matchExpressions:
+#         - key: NODE_LABEL_KEY
+#           operator: In
+#           values: 
+#           - NODE_LABEL_VALUE
 affinity: {}

--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,4 @@ require (
 )
 
 go 1.15
+replace code.cloudfoundry.org/quarks-utils => github.com/HCL-Cloud-Native-Labs/quarks-utils v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -23,4 +23,4 @@ require (
 )
 
 go 1.15
-replace code.cloudfoundry.org/quarks-utils => github.com/HCL-Cloud-Native-Labs/quarks-utils v0.0.2
+replace code.cloudfoundry.org/quarks-utils => github.com/HCL-Cloud-Native-Labs/quarks-utils v0.1.0

--- a/pkg/kube/apis/quarksjob/v1alpha1/register.go
+++ b/pkg/kube/apis/quarksjob/v1alpha1/register.go
@@ -3,7 +3,7 @@ package v1alpha1
 import (
 	"fmt"
 
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/kube/operator/operator.go
+++ b/pkg/kube/operator/operator.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	extv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
+	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	extv1client "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 


### PR DESCRIPTION
This PR helps to schedule pod on specific nodes in cluster & feature has been tested on openshift cluster. Here are the testing configurations & test results screen shots.

quarks-job has been installed by helm by passing following affinity configuration values.

I. Label openshift cluster node

oc label node xx.xx.xx.249 cf-node-group=cf-nodes

II. Helm values as below

affinity:
 nodeAffinity:
     requiredDuringSchedulingIgnoredDuringExecution:
       nodeSelectorTerms:
       - matchExpressions:
         - key: cf-node-group
           operator: In
           values: 
           - cf-nodes
           
III.  Test Results, Pod is scheduled on labeled node "xx.xx.xx.249"

<img width="949" alt="quarks-job" src="https://user-images.githubusercontent.com/81233158/125663798-d657577c-93a1-4118-b4c9-2b802bb459f8.PNG">
